### PR TITLE
feat: capture device metadata with each session

### DIFF
--- a/src/background/message-handler.ts
+++ b/src/background/message-handler.ts
@@ -82,7 +82,11 @@ export async function handleMessage(
 
     case 'CURSOR_BATCH': {
       store.addCursorBatch(message.data)
-      // No SESSION_UPDATED for cursor batches (too noisy)
+      return undefined
+    }
+
+    case 'DEVICE_METADATA': {
+      store.setDeviceMetadata(message.data)
       return undefined
     }
 

--- a/src/background/session-store.ts
+++ b/src/background/session-store.ts
@@ -1,4 +1,4 @@
-import type { CaptureSession, SelectedElementData, AnnotationData, CursorSampleData, VoiceSegment, ElementScreenshot } from '@shared/types'
+import type { CaptureSession, SelectedElementData, AnnotationData, CursorSampleData, VoiceSegment, ElementScreenshot, DeviceMetadata } from '@shared/types'
 import { createEmptySession } from '@shared/types'
 
 export class SessionStore {
@@ -41,6 +41,12 @@ export class SessionStore {
   addCursorBatch(samples: CursorSampleData[]): void {
     if (!this.session) return
     this.session.cursorTrace.push(...samples)
+    this.persist()
+  }
+
+  setDeviceMetadata(device: DeviceMetadata): void {
+    if (!this.session) return
+    this.session.device = device
     this.persist()
   }
 

--- a/src/content/device-metadata.ts
+++ b/src/content/device-metadata.ts
@@ -1,0 +1,49 @@
+import type { DeviceMetadata } from '@shared/types'
+
+export function parseBrowser(ua: string): { name: string; version: string } {
+  // Order matters: Edge contains "Chrome", so check Edge first
+  const edgeMatch = ua.match(/Edg\/(\S+)/)
+  if (edgeMatch) return { name: 'Edge', version: edgeMatch[1] }
+
+  const firefoxMatch = ua.match(/Firefox\/(\S+)/)
+  if (firefoxMatch) return { name: 'Firefox', version: firefoxMatch[1] }
+
+  const chromeMatch = ua.match(/Chrome\/(\S+)/)
+  if (chromeMatch) return { name: 'Chrome', version: chromeMatch[1] }
+
+  const safariMatch = ua.match(/Version\/(\S+).*Safari/)
+  if (safariMatch) return { name: 'Safari', version: safariMatch[1] }
+
+  return { name: 'Unknown', version: '' }
+}
+
+export function collectDeviceMetadata(win: Window): DeviceMetadata {
+  const ua = win.navigator.userAgent
+
+  let colorScheme: 'light' | 'dark' | 'unknown' = 'unknown'
+  if (win.matchMedia('(prefers-color-scheme: dark)').matches) {
+    colorScheme = 'dark'
+  } else if (win.matchMedia('(prefers-color-scheme: light)').matches) {
+    colorScheme = 'light'
+  }
+
+  return {
+    userAgent: ua,
+    browser: parseBrowser(ua),
+    os: win.navigator.platform,
+    language: win.navigator.language,
+    screen: {
+      width: win.screen.width,
+      height: win.screen.height,
+    },
+    window: {
+      innerWidth: win.innerWidth,
+      innerHeight: win.innerHeight,
+      outerWidth: win.outerWidth,
+      outerHeight: win.outerHeight,
+    },
+    devicePixelRatio: win.devicePixelRatio,
+    touchSupport: win.navigator.maxTouchPoints > 0,
+    colorScheme,
+  }
+}

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -2,6 +2,7 @@ import { CanvasOverlay } from './canvas-overlay'
 import { CursorTracker } from './cursor-tracker'
 import { extractElementData, findNearestElement } from './element-selector'
 import { inspectReactComponent } from './react-inspector'
+import { collectDeviceMetadata } from './device-metadata'
 import type { CaptureMode } from '@shared/messages'
 
 // Use dynamic import of css-selector-generator to keep it tree-shakeable
@@ -160,6 +161,7 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
       break
     case 'INJECT_CAPTURE':
       startCapture()
+      chrome.runtime.sendMessage({ type: 'DEVICE_METADATA', data: collectDeviceMetadata(window) })
       sendResponse({ ok: true })
       break
     case 'REMOVE_CAPTURE':

--- a/src/shared/formatter.ts
+++ b/src/shared/formatter.ts
@@ -5,6 +5,10 @@ export function formatSession(session: CaptureSession): string {
 
   sections.push(formatContext(session))
 
+  if (session.device) {
+    sections.push(formatDevice(session))
+  }
+
   if (session.selectedElement) {
     sections.push(formatTargetElement(session))
   }
@@ -37,6 +41,22 @@ function formatContext(session: CaptureSession): string {
     `- Viewport: ${session.viewport.width} x ${session.viewport.height}px`,
     `- Captured at: ${new Date(session.startedAt).toISOString().replace('T', ' ').slice(0, 19)}`,
   ]
+  return lines.join('\n')
+}
+
+function formatDevice(session: CaptureSession): string {
+  const d = session.device!
+  const lines = [
+    '## Device',
+    `- Browser: ${d.browser.name} ${d.browser.version}`,
+    `- OS: ${d.os}`,
+    `- Screen: ${d.screen.width} x ${d.screen.height}px`,
+    `- Window: ${d.window.innerWidth} x ${d.window.innerHeight}px (outer: ${d.window.outerWidth} x ${d.window.outerHeight}px)`,
+    `- Pixel ratio: ${d.devicePixelRatio}x`,
+    `- Language: ${d.language}`,
+  ]
+  if (d.touchSupport) lines.push('- Touch: supported')
+  if (d.colorScheme !== 'unknown') lines.push(`- Color scheme: ${d.colorScheme}`)
   return lines.join('\n')
 }
 

--- a/src/shared/messages.ts
+++ b/src/shared/messages.ts
@@ -1,4 +1,4 @@
-import type { SelectedElementData, AnnotationData, CursorSampleData, VoiceSegment, CaptureSession, ElementScreenshot } from './types'
+import type { SelectedElementData, AnnotationData, CursorSampleData, VoiceSegment, CaptureSession, ElementScreenshot, DeviceMetadata } from './types'
 
 export type Message =
   // Sidepanel → Service Worker
@@ -18,6 +18,7 @@ export type Message =
   | { type: 'ANNOTATION_ADDED'; data: AnnotationData }
   | { type: 'CURSOR_BATCH'; data: CursorSampleData[] }
   | { type: 'SCREENSHOT_REQUEST'; data: { selector: string; rect: { x: number; y: number; width: number; height: number }; timestampMs: number } }
+  | { type: 'DEVICE_METADATA'; data: DeviceMetadata }
   | { type: 'PONG' }
 
   // Service Worker → Content Script (response)

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1,3 +1,15 @@
+export interface DeviceMetadata {
+  userAgent: string
+  browser: { name: string; version: string }
+  os: string
+  language: string
+  screen: { width: number; height: number }
+  window: { innerWidth: number; innerHeight: number; outerWidth: number; outerHeight: number }
+  devicePixelRatio: number
+  touchSupport: boolean
+  colorScheme: 'light' | 'dark' | 'unknown'
+}
+
 export interface CaptureSession {
   id: string
   tabId: number
@@ -5,6 +17,7 @@ export interface CaptureSession {
   url: string
   title: string
   viewport: { width: number; height: number }
+  device: DeviceMetadata | null
 
   selectedElement: SelectedElementData | null
 
@@ -85,6 +98,7 @@ export function createEmptySession(id: string, tabId: number, url: string, title
     url,
     title,
     viewport,
+    device: null,
     selectedElement: null,
     voiceRecording: null,
     annotations: [],

--- a/tests/content/device-metadata.test.ts
+++ b/tests/content/device-metadata.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi } from 'vitest'
+import { collectDeviceMetadata, parseBrowser } from '../../src/content/device-metadata'
+
+describe('parseBrowser', () => {
+  it('detects Chrome', () => {
+    const result = parseBrowser('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36')
+    expect(result.name).toBe('Chrome')
+    expect(result.version).toBe('120.0.0.0')
+  })
+
+  it('detects Edge', () => {
+    const result = parseBrowser('Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36 Edg/120.0.0.0')
+    expect(result.name).toBe('Edge')
+    expect(result.version).toBe('120.0.0.0')
+  })
+
+  it('detects Firefox', () => {
+    const result = parseBrowser('Mozilla/5.0 (X11; Linux x86_64; rv:121.0) Gecko/20100101 Firefox/121.0')
+    expect(result.name).toBe('Firefox')
+    expect(result.version).toBe('121.0')
+  })
+
+  it('returns unknown for unrecognized UA', () => {
+    const result = parseBrowser('SomeBot/1.0')
+    expect(result.name).toBe('Unknown')
+  })
+})
+
+describe('collectDeviceMetadata', () => {
+  it('collects metadata from window and navigator', () => {
+    const mockWindow = {
+      navigator: {
+        userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 Chrome/120.0.0.0 Safari/537.36',
+        language: 'en-US',
+        platform: 'MacIntel',
+        maxTouchPoints: 0,
+      },
+      screen: { width: 2560, height: 1440 },
+      innerWidth: 1280,
+      innerHeight: 800,
+      outerWidth: 1440,
+      outerHeight: 900,
+      devicePixelRatio: 2,
+      matchMedia: vi.fn((query: string) => ({
+        matches: query === '(prefers-color-scheme: dark)',
+      })),
+    }
+
+    const result = collectDeviceMetadata(mockWindow as any)
+
+    expect(result.userAgent).toContain('Chrome/120')
+    expect(result.browser.name).toBe('Chrome')
+    expect(result.browser.version).toBe('120.0.0.0')
+    expect(result.os).toBe('MacIntel')
+    expect(result.language).toBe('en-US')
+    expect(result.screen).toEqual({ width: 2560, height: 1440 })
+    expect(result.window).toEqual({ innerWidth: 1280, innerHeight: 800, outerWidth: 1440, outerHeight: 900 })
+    expect(result.devicePixelRatio).toBe(2)
+    expect(result.touchSupport).toBe(false)
+    expect(result.colorScheme).toBe('dark')
+  })
+
+  it('detects touch support', () => {
+    const mockWindow = {
+      navigator: {
+        userAgent: 'Mozilla/5.0 Chrome/120.0.0.0',
+        language: 'en',
+        platform: 'Linux',
+        maxTouchPoints: 5,
+      },
+      screen: { width: 1920, height: 1080 },
+      innerWidth: 1920,
+      innerHeight: 1080,
+      outerWidth: 1920,
+      outerHeight: 1080,
+      devicePixelRatio: 1,
+      matchMedia: vi.fn(() => ({ matches: false })),
+    }
+
+    const result = collectDeviceMetadata(mockWindow as any)
+    expect(result.touchSupport).toBe(true)
+  })
+
+  it('detects light color scheme', () => {
+    const mockWindow = {
+      navigator: {
+        userAgent: 'Mozilla/5.0 Chrome/120.0.0.0',
+        language: 'en',
+        platform: 'Win32',
+        maxTouchPoints: 0,
+      },
+      screen: { width: 1920, height: 1080 },
+      innerWidth: 1920,
+      innerHeight: 1080,
+      outerWidth: 1920,
+      outerHeight: 1080,
+      devicePixelRatio: 1,
+      matchMedia: vi.fn((query: string) => ({
+        matches: query === '(prefers-color-scheme: light)',
+      })),
+    }
+
+    const result = collectDeviceMetadata(mockWindow as any)
+    expect(result.colorScheme).toBe('light')
+  })
+})

--- a/tests/shared/formatter.test.ts
+++ b/tests/shared/formatter.test.ts
@@ -10,6 +10,7 @@ function makeSession(overrides: Partial<CaptureSession> = {}): CaptureSession {
     url: 'https://example.com/page',
     title: 'Example Page',
     viewport: { width: 1200, height: 800 },
+    device: null,
     selectedElement: null,
     voiceRecording: null,
     annotations: [],
@@ -203,7 +204,6 @@ describe('formatSession', () => {
     expect(output).toContain('## Screenshots')
     expect(output).toContain('1. [00:05] div.hero > h1 (340x50px)')
     expect(output).toContain('2. [00:12] nav > a.pricing (120x30px)')
-    // base64 data should NOT appear in formatted output
     expect(output).not.toContain('base64,abc')
     expect(output).not.toContain('base64,xyz')
   })
@@ -211,5 +211,52 @@ describe('formatSession', () => {
   it('omits Screenshots section when no screenshots', () => {
     const output = formatSession(makeSession())
     expect(output).not.toContain('## Screenshots')
+  })
+
+  it('includes Device section when device metadata is present', () => {
+    const output = formatSession(makeSession({
+      device: {
+        userAgent: 'Mozilla/5.0 Chrome/120.0.0.0',
+        browser: { name: 'Chrome', version: '120.0.0.0' },
+        os: 'MacIntel',
+        language: 'en-US',
+        screen: { width: 2560, height: 1440 },
+        window: { innerWidth: 1280, innerHeight: 800, outerWidth: 1440, outerHeight: 900 },
+        devicePixelRatio: 2,
+        touchSupport: false,
+        colorScheme: 'dark',
+      },
+    }))
+    expect(output).toContain('## Device')
+    expect(output).toContain('Browser: Chrome 120.0.0.0')
+    expect(output).toContain('OS: MacIntel')
+    expect(output).toContain('Screen: 2560 x 1440px')
+    expect(output).toContain('Pixel ratio: 2x')
+    expect(output).toContain('Language: en-US')
+    expect(output).toContain('Color scheme: dark')
+    expect(output).not.toContain('Touch')
+  })
+
+  it('omits Device section when no device metadata', () => {
+    const output = formatSession(makeSession())
+    expect(output).not.toContain('## Device')
+  })
+
+  it('shows touch support when enabled', () => {
+    const output = formatSession(makeSession({
+      device: {
+        userAgent: 'Mozilla/5.0',
+        browser: { name: 'Chrome', version: '120' },
+        os: 'Linux',
+        language: 'en',
+        screen: { width: 1920, height: 1080 },
+        window: { innerWidth: 1920, innerHeight: 1080, outerWidth: 1920, outerHeight: 1080 },
+        devicePixelRatio: 1,
+        touchSupport: true,
+        colorScheme: 'unknown',
+      },
+    }))
+    expect(output).toContain('Touch: supported')
+    expect(output).not.toContain('Color scheme')
   })
 })

--- a/tests/shared/types.test.ts
+++ b/tests/shared/types.test.ts
@@ -11,6 +11,7 @@ describe('CaptureSession types', () => {
       url: 'https://example.com',
       title: 'Test',
       viewport: { width: 1200, height: 800 },
+      device: null,
       selectedElement: null,
       voiceRecording: null,
       annotations: [],
@@ -29,6 +30,7 @@ describe('CaptureSession types', () => {
       url: 'https://example.com',
       title: 'Test',
       viewport: { width: 1200, height: 800 },
+      device: null,
       selectedElement: {
         selector: 'div.hero > h1',
         computedStyles: { 'font-size': '32px' },


### PR DESCRIPTION
## What this adds

Captures device and browser metadata automatically at the start of each capture session. This is context that users consistently forget to mention when reporting issues: screen size, browser version, pixel ratio, OS.

## What gets captured

| Field | Source | Example |
|-------|--------|---------|
| Browser name + version | User agent parsing | Chrome 120.0.0.0 |
| OS | `navigator.platform` | MacIntel |
| Screen resolution | `screen.width/height` | 2560 x 1440 |
| Window dimensions | `innerWidth/Height`, `outerWidth/Height` | 1280 x 800 (outer: 1440 x 900) |
| Device pixel ratio | `window.devicePixelRatio` | 2x |
| Touch support | `navigator.maxTouchPoints` | yes/no |
| Color scheme | `prefers-color-scheme` media query | dark/light |
| Language | `navigator.language` | en-US |

**Not captured:** Other installed extensions (Chrome blocks cross-extension enumeration for security).

## How it works

The content script collects metadata from `window` and `navigator` on `INJECT_CAPTURE`, sends it to the service worker via a `DEVICE_METADATA` message, and the SessionStore attaches it to the session. The formatter renders it as a "Device" section between Context and Target Element.

## Example output

```
## Device
- Browser: Chrome 120.0.0.0
- OS: MacIntel
- Screen: 2560 x 1440px
- Window: 1280 x 800px (outer: 1440 x 900px)
- Pixel ratio: 2x
- Language: en-US
- Color scheme: dark
```

## Validation

- 10 new tests (7 for metadata collection + browser parsing, 3 for formatter output)
- 72 total tests pass (up from 62)
- Clean build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sessions now capture device metadata during capture (browser, OS, screen/window sizes, pixel ratio, touch support, language, color scheme) and show a Device section when available.

* **Bug Fixes**
  * Prevented unintended continuation in cursor batch handling to avoid spurious behavior during captures.

* **Tests**
  * Added unit tests covering device metadata collection and session formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->