### PR TITLE
fix: reduce cursor dwell noise with dedup and higher threshold

### DIFF
--- a/src/shared/dwell.ts
+++ b/src/shared/dwell.ts
@@ -6,13 +6,13 @@ export function distance(a: CursorSampleData, b: CursorSampleData): number {
 }
 
 const DWELL_RADIUS_PX = 30
-const DWELL_MIN_MS = 500
+const DWELL_MIN_MS = 1000
 
 /**
  * Compute dwell times for cursor samples.
  *
  * A "dwell" is a group of consecutive samples that all stay within a 30px
- * radius of the group's anchor point for longer than 500ms. Each sample in
+ * radius of the group's anchor point for longer than 1000ms. Each sample in
  * such a group gets its `dwellMs` set to the total duration of the group.
  * Samples that are not part of a dwell group keep `dwellMs` undefined.
  *
@@ -46,4 +46,38 @@ export function computeDwells(samples: CursorSampleData[]): CursorSampleData[] {
   }
 
   return result
+}
+
+/**
+ * Collapse consecutive dwell entries that share the same `nearestElement`
+ * into a single entry.
+ *
+ * Only samples with a defined `dwellMs` are considered dwell entries.
+ * Consecutive entries with identical `nearestElement` are merged into one
+ * entry whose `timestampMs` is the earliest and whose `dwellMs` spans from
+ * the first entry's start to the last entry's end.
+ */
+export function collapseDwells(samples: CursorSampleData[]): CursorSampleData[] {
+  const dwells = samples.filter((s) => s.dwellMs != null && s.dwellMs > 0)
+  if (dwells.length === 0) return []
+
+  const collapsed: CursorSampleData[] = []
+  let current = { ...dwells[0] }
+
+  for (let i = 1; i < dwells.length; i++) {
+    const entry = dwells[i]
+    if (entry.nearestElement === current.nearestElement) {
+      // Extend the current entry to span through this one
+      const currentEnd = current.timestampMs + (current.dwellMs ?? 0)
+      const entryEnd = entry.timestampMs + (entry.dwellMs ?? 0)
+      const newEnd = Math.max(currentEnd, entryEnd)
+      current.dwellMs = newEnd - current.timestampMs
+    } else {
+      collapsed.push(current)
+      current = { ...entry }
+    }
+  }
+  collapsed.push(current)
+
+  return collapsed
 }

--- a/src/sidepanel/components/OutputView.tsx
+++ b/src/sidepanel/components/OutputView.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from 'react'
 import type { CaptureSession } from '@shared/types'
 import { formatSession } from '@shared/formatter'
-import { computeDwells } from '@shared/dwell'
+import { computeDwells, collapseDwells } from '@shared/dwell'
 import { CopyButton } from './CopyButton'
 
 interface OutputViewProps {
@@ -13,7 +13,7 @@ export function OutputView({ session, onBack }: OutputViewProps) {
   const output = useMemo(() => {
     const sessionWithDwells = {
       ...session,
-      cursorTrace: computeDwells(session.cursorTrace),
+      cursorTrace: collapseDwells(computeDwells(session.cursorTrace)),
     }
     return formatSession(sessionWithDwells)
   }, [session])

--- a/tests/shared/dwell.test.ts
+++ b/tests/shared/dwell.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { computeDwells, distance } from '@shared/dwell'
+import { computeDwells, collapseDwells, distance } from '@shared/dwell'
 import type { CursorSampleData } from '@shared/types'
 
 describe('distance', () => {
@@ -20,7 +20,7 @@ describe('computeDwells', () => {
     expect(computeDwells([])).toEqual([])
   })
 
-  it('does not set dwellMs when duration is under 500ms', () => {
+  it('does not set dwellMs when duration is under 1000ms', () => {
     const samples: CursorSampleData[] = [
       { x: 100, y: 100, timestampMs: 0 },
       { x: 105, y: 100, timestampMs: 200 },
@@ -30,19 +30,19 @@ describe('computeDwells', () => {
     expect(result.every((s) => s.dwellMs === undefined)).toBe(true)
   })
 
-  it('sets dwellMs for a group that stays within 30px for >500ms', () => {
+  it('sets dwellMs for a group that stays within 30px for >1000ms', () => {
     const samples: CursorSampleData[] = [
       { x: 100, y: 100, timestampMs: 0 },
-      { x: 110, y: 105, timestampMs: 200 },
-      { x: 105, y: 110, timestampMs: 400 },
-      { x: 108, y: 103, timestampMs: 600 },
+      { x: 110, y: 105, timestampMs: 300 },
+      { x: 105, y: 110, timestampMs: 700 },
+      { x: 108, y: 103, timestampMs: 1200 },
     ]
     const result = computeDwells(samples)
-    // Duration from first to last = 600ms, all within 30px
-    expect(result[0].dwellMs).toBe(600)
-    expect(result[1].dwellMs).toBe(600)
-    expect(result[2].dwellMs).toBe(600)
-    expect(result[3].dwellMs).toBe(600)
+    // Duration from first to last = 1200ms, all within 30px
+    expect(result[0].dwellMs).toBe(1200)
+    expect(result[1].dwellMs).toBe(1200)
+    expect(result[2].dwellMs).toBe(1200)
+    expect(result[3].dwellMs).toBe(1200)
   })
 
   it('does not mutate the input array', () => {
@@ -57,39 +57,100 @@ describe('computeDwells', () => {
 
   it('handles multiple dwell groups separated by movement', () => {
     const samples: CursorSampleData[] = [
-      // First dwell group: near (100, 100) for 800ms
+      // First dwell group: near (100, 100) for 1200ms
       { x: 100, y: 100, timestampMs: 0 },
-      { x: 105, y: 102, timestampMs: 300 },
-      { x: 103, y: 98, timestampMs: 800 },
+      { x: 105, y: 102, timestampMs: 500 },
+      { x: 103, y: 98, timestampMs: 1200 },
       // Movement: jumps far away
-      { x: 500, y: 500, timestampMs: 900 },
-      // Second dwell group: near (500, 500) for 700ms
-      { x: 502, y: 503, timestampMs: 1200 },
-      { x: 498, y: 501, timestampMs: 1600 },
+      { x: 500, y: 500, timestampMs: 1300 },
+      // Second dwell group: near (500, 500) for 1100ms
+      { x: 502, y: 503, timestampMs: 1800 },
+      { x: 498, y: 501, timestampMs: 2400 },
     ]
     const result = computeDwells(samples)
-    // First group: indices 0-2, duration = 800ms
-    expect(result[0].dwellMs).toBe(800)
-    expect(result[1].dwellMs).toBe(800)
-    expect(result[2].dwellMs).toBe(800)
+    // First group: indices 0-2, duration = 1200ms
+    expect(result[0].dwellMs).toBe(1200)
+    expect(result[1].dwellMs).toBe(1200)
+    expect(result[2].dwellMs).toBe(1200)
     // Movement sample: starts its own group with samples[4] and [5]
     // samples[3] at (500,500), samples[4] at (502,503) is within 30px
     // samples[5] at (498,501) is within 30px of (500,500)
-    // Duration from sample[3] to sample[5] = 1600 - 900 = 700ms
-    expect(result[3].dwellMs).toBe(700)
-    expect(result[4].dwellMs).toBe(700)
-    expect(result[5].dwellMs).toBe(700)
+    // Duration from sample[3] to sample[5] = 2400 - 1300 = 1100ms
+    expect(result[3].dwellMs).toBe(1100)
+    expect(result[4].dwellMs).toBe(1100)
+    expect(result[5].dwellMs).toBe(1100)
   })
 
   it('does not count samples beyond 30px radius', () => {
     const samples: CursorSampleData[] = [
       { x: 0, y: 0, timestampMs: 0 },
-      { x: 0, y: 0, timestampMs: 600 },
-      { x: 50, y: 50, timestampMs: 700 }, // > 30px away from anchor
+      { x: 0, y: 0, timestampMs: 1200 },
+      { x: 50, y: 50, timestampMs: 1300 }, // > 30px away from anchor
     ]
     const result = computeDwells(samples)
-    expect(result[0].dwellMs).toBe(600)
-    expect(result[1].dwellMs).toBe(600)
+    expect(result[0].dwellMs).toBe(1200)
+    expect(result[1].dwellMs).toBe(1200)
     expect(result[2].dwellMs).toBeUndefined() // lone sample, no dwell
+  })
+})
+
+describe('collapseDwells', () => {
+  it('returns empty array for empty input', () => {
+    expect(collapseDwells([])).toEqual([])
+  })
+
+  it('single dwell passes through unchanged', () => {
+    const samples: CursorSampleData[] = [
+      { x: 10, y: 20, timestampMs: 0, dwellMs: 1500, nearestElement: 'div.hero' },
+    ]
+    const result = collapseDwells(samples)
+    expect(result).toHaveLength(1)
+    expect(result[0]).toEqual({
+      x: 10,
+      y: 20,
+      timestampMs: 0,
+      dwellMs: 1500,
+      nearestElement: 'div.hero',
+    })
+  })
+
+  it('collapses consecutive same-element dwells into one', () => {
+    const samples: CursorSampleData[] = [
+      { x: 10, y: 20, timestampMs: 1000, dwellMs: 1200, nearestElement: 'h1.font-display' },
+      { x: 12, y: 22, timestampMs: 1100, dwellMs: 1200, nearestElement: 'h1.font-display' },
+      { x: 11, y: 21, timestampMs: 1200, dwellMs: 1200, nearestElement: 'h1.font-display' },
+    ]
+    const result = collapseDwells(samples)
+    expect(result).toHaveLength(1)
+    expect(result[0].timestampMs).toBe(1000)
+    // Span from first start (1000) to last end (1200 + 1200 = 2400)
+    expect(result[0].dwellMs).toBe(1400)
+    expect(result[0].nearestElement).toBe('h1.font-display')
+  })
+
+  it('preserves dwells on different elements as separate entries', () => {
+    const samples: CursorSampleData[] = [
+      { x: 10, y: 20, timestampMs: 0, dwellMs: 1500, nearestElement: 'div.hero' },
+      { x: 10, y: 20, timestampMs: 200, dwellMs: 1500, nearestElement: 'div.hero' },
+      { x: 100, y: 200, timestampMs: 2000, dwellMs: 1100, nearestElement: 'button.cta' },
+      { x: 100, y: 200, timestampMs: 2200, dwellMs: 1100, nearestElement: 'button.cta' },
+      { x: 300, y: 400, timestampMs: 4000, dwellMs: 1300, nearestElement: 'footer.main' },
+    ]
+    const result = collapseDwells(samples)
+    expect(result).toHaveLength(3)
+    expect(result[0].nearestElement).toBe('div.hero')
+    expect(result[1].nearestElement).toBe('button.cta')
+    expect(result[2].nearestElement).toBe('footer.main')
+  })
+
+  it('ignores samples without dwellMs', () => {
+    const samples: CursorSampleData[] = [
+      { x: 10, y: 20, timestampMs: 0 },
+      { x: 10, y: 20, timestampMs: 100, dwellMs: 1500, nearestElement: 'div.hero' },
+      { x: 50, y: 50, timestampMs: 500 },
+    ]
+    const result = collapseDwells(samples)
+    expect(result).toHaveLength(1)
+    expect(result[0].nearestElement).toBe('div.hero')
   })
 })


### PR DESCRIPTION
## Summary

The cursor behavior section in session output was producing many duplicate/near-duplicate entries. For example, a single dwell over an `h1` element would generate 5 identical lines like:

```
- [00:03–00:04] Dwelled 0.6s over h1.font-display.text-hero
- [00:03–00:04] Dwelled 0.6s over h1.font-display.text-hero
- [00:03–00:04] Dwelled 0.6s over h1.font-display.text-hero
```

**Root cause:** `computeDwells` stamps every sample in a dwell group with the same `dwellMs`, and the formatter then emits a line for each one.

**Fixes:**

- **Raised `DWELL_MIN_MS` from 500ms to 1000ms** — filters out brief/incidental hovers so only intentional 1s+ dwells are reported
- **Added `collapseDwells()` function** — merges consecutive dwell entries sharing the same `nearestElement` into a single entry spanning the full time range (earliest start to latest end)
- **Wired `collapseDwells` into `OutputView.tsx`** — called after `computeDwells` before passing data to the formatter

## Test plan

- [x] Updated existing `computeDwells` tests for the new 1000ms threshold
- [x] Added 4 new tests for `collapseDwells`: empty input, single passthrough, consecutive same-element collapse, different-element preservation
- [x] `bun run test` — all 69 tests pass
- [x] `bun run build` — production build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)