### PR TITLE
Fix microphone permission flow for voice transcription

### DIFF
--- a/public/mic-permission.html
+++ b/public/mic-permission.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>PointDev — Microphone Access</title>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      min-height: 100vh;
+      background: #f5f5f5;
+      color: #1a1a1a;
+    }
+    @media (prefers-color-scheme: dark) {
+      body { background: #1a1a1a; color: #e5e5e5; }
+      .card { background: #2a2a2a; border-color: #333; }
+    }
+    .card {
+      max-width: 400px;
+      padding: 32px;
+      background: white;
+      border-radius: 12px;
+      border: 1px solid #e0e0e0;
+      text-align: center;
+    }
+    h1 { font-size: 20px; margin-bottom: 8px; }
+    p { font-size: 14px; color: #6b7280; margin-bottom: 24px; line-height: 1.5; }
+    button {
+      padding: 12px 32px;
+      background: #2563eb;
+      color: white;
+      border: none;
+      border-radius: 8px;
+      font-size: 15px;
+      cursor: pointer;
+    }
+    button:hover { background: #1d4ed8; }
+    button:disabled { background: #9ca3af; cursor: default; }
+    .status { margin-top: 16px; font-size: 13px; }
+    .success { color: #16a34a; }
+    .error { color: #dc2626; }
+  </style>
+</head>
+<body>
+  <div class="card">
+    <h1>PointDev needs microphone access</h1>
+    <p>Voice narration requires your browser's permission to use the microphone. Click below and allow when prompted.</p>
+    <button id="grant">Allow Microphone</button>
+    <div id="status" class="status"></div>
+  </div>
+  <script src="mic-permission.js"></script>
+</body>
+</html>

--- a/public/mic-permission.js
+++ b/public/mic-permission.js
@@ -1,0 +1,29 @@
+// Visible extension page that can trigger Chrome's microphone permission prompt.
+// Offscreen documents and sidepanels cannot present permission dialogs.
+
+const btn = document.getElementById('grant');
+const status = document.getElementById('status');
+
+btn.addEventListener('click', async () => {
+  btn.disabled = true;
+  status.textContent = 'Requesting access...';
+  status.className = 'status';
+
+  try {
+    const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+    stream.getTracks().forEach(track => track.stop());
+
+    status.textContent = 'Microphone access granted. You can close this tab.';
+    status.className = 'status success';
+
+    // Notify the extension that permission was granted
+    chrome.runtime.sendMessage({ type: 'MIC_PERMISSION_GRANTED' });
+
+    // Auto-close after a short delay
+    setTimeout(() => window.close(), 1500);
+  } catch (err) {
+    status.textContent = 'Permission denied. Please try again and click "Allow" when prompted.';
+    status.className = 'status error';
+    btn.disabled = false;
+  }
+});

--- a/public/offscreen.js
+++ b/public/offscreen.js
@@ -20,8 +20,9 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
   } else if (message.type === 'OFFSCREEN_SPEECH_STOP') {
     stopRecognition();
     sendResponse({ ok: true });
+  } else {
+    return false; // Don't hold channel for unhandled messages
   }
-  return true;
 });
 
 async function requestMicAndStart() {

--- a/src/sidepanel/hooks/useSpeechRecognition.ts
+++ b/src/sidepanel/hooks/useSpeechRecognition.ts
@@ -14,20 +14,21 @@ interface UseSpeechRecognitionReturn {
 
 // Speech recognition runs in an offscreen document because Chrome extension
 // sidepanels cannot trigger microphone permission prompts.
+// The initial mic permission must be granted from a visible extension page
+// (mic-permission.html) because offscreen documents also can't show prompts.
 export function useSpeechRecognition(): UseSpeechRecognitionReturn {
   const [isListening, setIsListening] = useState(false)
   const [transcript, setTranscript] = useState('')
   const [interimTranscript, setInterimTranscript] = useState('')
   const [segments, setSegments] = useState<VoiceSegment[]>([])
   const [error, setError] = useState<string | null>(null)
-  const isListeningRef = useRef(false)
+  const pendingStartRef = useRef<number | null>(null)
 
-  // Listen for messages from the offscreen document
+  // Listen for messages from the offscreen document and mic-permission page
   useEffect(() => {
     const listener = (message: any) => {
       if (message.type === 'OFFSCREEN_SPEECH_STARTED') {
         setIsListening(true)
-        isListeningRef.current = true
       } else if (message.type === 'OFFSCREEN_SPEECH_RESULT') {
         if (message.segments && message.segments.length > 0) {
           setSegments(prev => {
@@ -42,7 +43,12 @@ export function useSpeechRecognition(): UseSpeechRecognitionReturn {
       } else if (message.type === 'OFFSCREEN_SPEECH_ERROR') {
         setError(message.error)
         setIsListening(false)
-        isListeningRef.current = false
+      } else if (message.type === 'MIC_PERMISSION_GRANTED') {
+        // Permission was just granted via the visible page — start speech if pending
+        if (pendingStartRef.current !== null) {
+          startOffscreen(pendingStartRef.current)
+          pendingStartRef.current = null
+        }
       }
     }
 
@@ -50,13 +56,7 @@ export function useSpeechRecognition(): UseSpeechRecognitionReturn {
     return () => chrome.runtime.onMessage.removeListener(listener)
   }, [])
 
-  const start = useCallback(async (captureStartedAt: number) => {
-    setTranscript('')
-    setInterimTranscript('')
-    setSegments([])
-    setError(null)
-
-    // Create offscreen document if it doesn't exist
+  async function startOffscreen(captureStartedAt: number) {
     try {
       await chrome.offscreen.createDocument({
         url: chrome.runtime.getURL('offscreen.html'),
@@ -64,23 +64,46 @@ export function useSpeechRecognition(): UseSpeechRecognitionReturn {
         justification: 'Voice transcription via Web Speech API requires microphone access',
       })
     } catch {
-      // Document may already exist — that's fine
+      // Document may already exist
     }
 
-    // Tell the offscreen document to start listening
     chrome.runtime.sendMessage({
       type: 'OFFSCREEN_SPEECH_START',
       captureStartedAt,
     })
+  }
+
+  const start = useCallback(async (captureStartedAt: number) => {
+    setTranscript('')
+    setInterimTranscript('')
+    setSegments([])
+    setError(null)
+
+    // Check if microphone permission is already granted
+    try {
+      const permStatus = await navigator.permissions.query({ name: 'microphone' as PermissionName })
+      if (permStatus.state === 'granted') {
+        startOffscreen(captureStartedAt)
+        return
+      }
+    } catch {
+      // permissions.query may not be available — try offscreen directly
+      startOffscreen(captureStartedAt)
+      return
+    }
+
+    // Mic not yet granted — open the permission page in a new tab.
+    // Must use a visible extension page because offscreen/sidepanel can't show prompts.
+    pendingStartRef.current = captureStartedAt
+    window.open(chrome.runtime.getURL('mic-permission.html'))
   }, [])
 
   const stop = useCallback(() => {
     chrome.runtime.sendMessage({ type: 'OFFSCREEN_SPEECH_STOP' })
     setIsListening(false)
-    isListeningRef.current = false
     setInterimTranscript('')
+    pendingStartRef.current = null
   }, [])
 
-  // Offscreen documents are always available in MV3 with the offscreen permission
   return { isAvailable: true, isListening, transcript, interimTranscript, segments, error, start, stop }
 }


### PR DESCRIPTION
## Summary

- Chrome offscreen documents and sidepanels cannot present the browser's microphone permission prompt. `getUserMedia` fails silently with `NotAllowedError: Permission dismissed`.
- New flow: on first capture, the sidepanel checks `navigator.permissions.query({ name: 'microphone' })`. If not yet granted, it opens `mic-permission.html` in a new tab where the user clicks "Allow Microphone" and Chrome shows the real permission dialog. Once granted, the page sends `MIC_PERMISSION_GRANTED` back to the extension and auto-closes. The offscreen document then uses the already-granted permission for Web Speech API.
- This is a one-time setup. After the initial grant, subsequent captures go straight to the offscreen document without opening a tab.
- Also fixes the offscreen document's `onMessage` listener to return `false` for unhandled message types (consistent with PR #5).

## Test plan

- [ ] Start capture for the first time. Mic permission tab should open automatically.
- [ ] Click "Allow Microphone" in the tab. Chrome permission prompt should appear.
- [ ] Grant permission. Tab auto-closes. Voice transcription starts in the sidepanel.
- [ ] Stop and start a second capture. No permission tab should open (already granted). Transcription should start immediately.
- [ ] All 84 existing tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)