### PR TITLE
Fix mic tab not reopened after browser restart

### DIFF
--- a/public/mic-permission.js
+++ b/public/mic-permission.js
@@ -11,6 +11,27 @@ let recognition = null;
 let captureStartedAt = 0;
 let processedResults = 0;
 
+// On load, announce this tab is alive and check if mic is already granted
+(async function init() {
+  try {
+    const permStatus = await navigator.permissions.query({ name: 'microphone' });
+    if (permStatus.state === 'granted') {
+      // Already granted (from a previous session) — skip the button
+      btn.style.display = 'none';
+      status.textContent = 'Microphone ready. Keep this tab open during capture.';
+      status.className = 'status success';
+      chrome.storage.local.set({ pointdev_mic_granted: true });
+      chrome.runtime.sendMessage({ type: 'MIC_TAB_READY' });
+      return;
+    }
+  } catch {
+    // Permissions API not available — show the button
+  }
+
+  // Announce tab is alive but mic needs granting
+  chrome.runtime.sendMessage({ type: 'MIC_TAB_READY' });
+})();
+
 btn.addEventListener('click', async () => {
   btn.disabled = true;
   status.textContent = 'Requesting access...';
@@ -20,10 +41,10 @@ btn.addEventListener('click', async () => {
     const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
     stream.getTracks().forEach(track => track.stop());
 
-    status.textContent = 'Microphone access granted. Keep this tab open during capture.';
+    btn.style.display = 'none';
+    status.textContent = 'Microphone ready. Keep this tab open during capture.';
     status.className = 'status success';
 
-    // Persist the grant flag and notify the extension
     chrome.storage.local.set({ pointdev_mic_granted: true });
     chrome.runtime.sendMessage({ type: 'MIC_PERMISSION_GRANTED' });
   } catch (err) {
@@ -43,6 +64,8 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
   } else if (message.type === 'SPEECH_STOP') {
     stopRecognition();
     sendResponse({ ok: true });
+  } else if (message.type === 'MIC_TAB_PING') {
+    sendResponse({ alive: true });
   } else {
     return false;
   }
@@ -106,7 +129,6 @@ function startRecognition() {
   };
 
   recognition.onend = () => {
-    // Auto-restart if still supposed to be listening
     if (recognition) {
       try { recognition.start(); } catch (e) { /* already stopped */ }
     }
@@ -121,6 +143,6 @@ function stopRecognition() {
     recognition = null;
     r.stop();
   }
-  status.textContent = 'Microphone access granted. Keep this tab open during capture.';
+  status.textContent = 'Microphone ready. Keep this tab open during capture.';
   status.className = 'status success';
 }

--- a/src/sidepanel/hooks/useSpeechRecognition.ts
+++ b/src/sidepanel/hooks/useSpeechRecognition.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useCallback, useRef } from 'react'
 import type { VoiceSegment } from '@shared/types'
 
 interface UseSpeechRecognitionReturn {
@@ -18,6 +18,8 @@ const MIC_GRANTED_KEY = 'pointdev_mic_granted'
 
 // Speech recognition runs in mic-permission.html (a visible extension tab)
 // because neither sidepanels nor offscreen documents can reliably get mic access.
+// The tab must stay open during capture. On sidepanel mount, we ensure the tab
+// exists — reopening it silently if the browser was restarted.
 export function useSpeechRecognition(): UseSpeechRecognitionReturn {
   const [isListening, setIsListening] = useState(false)
   const [micPermission, setMicPermission] = useState<'checking' | 'granted' | 'needs-setup'>('checking')
@@ -25,26 +27,41 @@ export function useSpeechRecognition(): UseSpeechRecognitionReturn {
   const [interimTranscript, setInterimTranscript] = useState('')
   const [segments, setSegments] = useState<VoiceSegment[]>([])
   const [error, setError] = useState<string | null>(null)
+  const tabReadyRef = useRef(false)
 
-  // Check mic permission on mount and auto-open setup if needed
+  // Ensure mic-permission tab is alive on mount
   useEffect(() => {
-    async function checkMic() {
-      try {
-        const stored = await chrome.storage.local.get(MIC_GRANTED_KEY)
-        if (stored[MIC_GRANTED_KEY]) {
-          setMicPermission('granted')
-          return
-        }
-      } catch {
-        // storage not available in test
+    async function ensureMicTab() {
+      const hasFlag = await chrome.storage.local.get(MIC_GRANTED_KEY)
+        .then(s => !!s[MIC_GRANTED_KEY])
+        .catch(() => false)
+
+      // Ping the mic tab to see if it's alive
+      const tabAlive = await new Promise<boolean>(resolve => {
+        chrome.runtime.sendMessage({ type: 'MIC_TAB_PING' }, response => {
+          // If no tab is listening, Chrome sets lastError
+          if (chrome.runtime.lastError || !response?.alive) {
+            resolve(false)
+          } else {
+            resolve(true)
+          }
+        })
+      })
+
+      if (tabAlive) {
+        // Tab is alive — we're good
+        tabReadyRef.current = true
+        setMicPermission(hasFlag ? 'granted' : 'needs-setup')
+        return
       }
 
-      // Not granted — auto-open the permission page
-      setMicPermission('needs-setup')
+      // Tab is not alive — open it
+      // If permission was previously granted, the tab will auto-detect and hide the button
       window.open(chrome.runtime.getURL('mic-permission.html'))
+      setMicPermission(hasFlag ? 'granted' : 'needs-setup')
     }
 
-    checkMic()
+    ensureMicTab()
   }, [])
 
   // Listen for messages from the mic-permission tab
@@ -68,6 +85,8 @@ export function useSpeechRecognition(): UseSpeechRecognitionReturn {
         setIsListening(false)
       } else if (message.type === 'MIC_PERMISSION_GRANTED') {
         setMicPermission('granted')
+      } else if (message.type === 'MIC_TAB_READY') {
+        tabReadyRef.current = true
       }
     }
 
@@ -86,11 +105,10 @@ export function useSpeechRecognition(): UseSpeechRecognitionReturn {
     setError(null)
 
     if (micPermission !== 'granted') {
-      setError('Microphone not enabled. Grant permission first, then try again.')
+      setError('Microphone not enabled. Grant permission in the PointDev tab first.')
       return
     }
 
-    // Send start command to mic-permission.html tab via broadcast
     chrome.runtime.sendMessage({
       type: 'SPEECH_START',
       captureStartedAt,

--- a/tests/sidepanel/hooks/useSpeechRecognition.test.ts
+++ b/tests/sidepanel/hooks/useSpeechRecognition.test.ts
@@ -16,7 +16,11 @@ beforeEach(() => {
           if (idx >= 0) messageListeners.splice(idx, 1)
         }),
       },
-      sendMessage: vi.fn(),
+      sendMessage: vi.fn((msg: any, cb?: any) => {
+        // Simulate MIC_TAB_PING response — tab is alive
+        if (msg.type === 'MIC_TAB_PING' && cb) cb({ alive: true })
+      }),
+      lastError: null,
       getURL: vi.fn((path: string) => `chrome-extension://test/${path}`),
     },
     storage: {


### PR DESCRIPTION
## Summary

- Mic-permission tab (which runs SpeechRecognition) doesn't persist across browser restarts, but the `chrome.storage.local` grant flag does. The sidepanel trusted the flag and never reopened the tab, so speech commands went nowhere.
- On sidepanel mount, now pings the mic tab via `MIC_TAB_PING`. If no response, reopens it automatically.
- The mic tab now auto-detects existing permission on load via `navigator.permissions.query` and hides the "Allow Microphone" button if already granted.

Fixes #17

## Test plan

- [x] All 84 tests pass
- [ ] Close Chrome completely, reopen, open sidepanel. Mic tab should auto-open.
- [ ] If mic was previously granted, tab shows "Microphone ready" (no button).
- [ ] Start capture, voice transcription works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Improved microphone readiness detection with automatic tab state verification
  * Enhanced permission handling with better status visibility

* **Bug Fixes**
  * Added fallback support for browsers without Permissions API
  * Clearer guidance directing users to grant microphone permissions in the correct location

* **Tests**
  * Updated test infrastructure to support improved tab communication patterns

<!-- end of auto-generated comment: release notes by coderabbit.ai -->