### PR TITLE
Add box model and element context to annotations

### DIFF
--- a/src/content/element-selector.ts
+++ b/src/content/element-selector.ts
@@ -1,4 +1,4 @@
-import type { SelectedElementData } from '@shared/types'
+import type { SelectedElementData, BoxModel } from '@shared/types'
 
 export const COMPUTED_STYLE_PROPS = [
   'font-size', 'font-weight', 'font-family',
@@ -45,8 +45,22 @@ export function extractElementData(
   return {
     selector,
     computedStyles: styles,
+    boxModel: getBoxModel(element, computed),
     domSubtree,
     boundingRect: boundingRect as DOMRect,
+  }
+}
+
+export function getBoxModel(element: Element, computed: CSSStyleDeclaration): BoxModel {
+  const px = (prop: string) => parseFloat(computed.getPropertyValue(prop)) || 0
+  return {
+    content: {
+      width: element.clientWidth - px('padding-left') - px('padding-right'),
+      height: element.clientHeight - px('padding-top') - px('padding-bottom'),
+    },
+    padding: { top: px('padding-top'), right: px('padding-right'), bottom: px('padding-bottom'), left: px('padding-left') },
+    border: { top: px('border-top-width'), right: px('border-right-width'), bottom: px('border-bottom-width'), left: px('border-left-width') },
+    margin: { top: px('margin-top'), right: px('margin-right'), bottom: px('margin-bottom'), left: px('margin-left') },
   }
 }
 

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -106,6 +106,17 @@ function handleMouseUp(e: MouseEvent) {
     const nearestEl = findNearestElement(viewportX, viewportY, document)
     if (nearestEl && generateSelector) {
       annotation.nearestElement = generateSelector(nearestEl)
+      const elData = extractElementData(
+        nearestEl,
+        annotation.nearestElement,
+        window.getComputedStyle.bind(window),
+        { scrollX: window.scrollX, scrollY: window.scrollY }
+      )
+      annotation.nearestElementContext = {
+        computedStyles: elData.computedStyles,
+        boxModel: elData.boxModel,
+        domSubtree: elData.domSubtree,
+      }
     }
 
     chrome.runtime.sendMessage({ type: 'ANNOTATION_ADDED', data: annotation })

--- a/src/shared/formatter.ts
+++ b/src/shared/formatter.ts
@@ -1,4 +1,4 @@
-import type { CaptureSession, CircleCoords, ArrowCoords } from './types'
+import type { CaptureSession, CircleCoords, ArrowCoords, BoxModel } from './types'
 
 export function formatSession(session: CaptureSession): string {
   const sections: string[] = []
@@ -74,6 +74,10 @@ function formatTargetElement(session: CaptureSession): string {
     lines.push(`- Computed: ${computedStr}`)
   }
 
+  if (el.boxModel) {
+    lines.push(`- Box Model: ${formatBoxModel(el.boxModel)}`)
+  }
+
   lines.push(`- DOM: ${truncateDom(el.domSubtree)}`)
 
   return lines.join('\n')
@@ -111,6 +115,15 @@ function reconstructShorthand(styles: Record<string, string>, prop: string): str
   return `${prop}: ${top} ${right} ${bottom} ${left}`
 }
 
+function formatBoxModel(box: BoxModel): string {
+  const fmt = (sides: { top: number; right: number; bottom: number; left: number }) => {
+    const { top, right, bottom, left } = sides
+    if (top === right && right === bottom && bottom === left) return `${top}px`
+    return `${top} ${right} ${bottom} ${left}px`
+  }
+  return `${box.content.width}x${box.content.height} (padding: ${fmt(box.padding)}, border: ${fmt(box.border)}, margin: ${fmt(box.margin)})`
+}
+
 function truncateDom(html: string): string {
   if (html.length <= 500) return html
   return html.slice(0, 500) + '<!-- truncated -->'
@@ -137,6 +150,14 @@ function formatAnnotations(session: CaptureSession): string {
     } else {
       const a = ann.coordinates as ArrowCoords
       lines.push(`${i + 1}. [${ts}] Arrow from (${a.startX}, ${a.startY}) to (${a.endX}, ${a.endY}), pointing at ${target}`)
+    }
+
+    if (ann.nearestElementContext) {
+      const ctx = ann.nearestElementContext
+      const styles = formatComputedStyles(ctx.computedStyles)
+      if (styles) lines.push(`   Computed: ${styles}`)
+      if (ctx.boxModel) lines.push(`   Box Model: ${formatBoxModel(ctx.boxModel)}`)
+      lines.push(`   DOM: ${truncateDom(ctx.domSubtree)}`)
     }
   }
   return lines.join('\n')

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -38,9 +38,17 @@ export interface ElementScreenshot {
   height: number
 }
 
+export interface BoxModel {
+  content: { width: number; height: number }
+  padding: { top: number; right: number; bottom: number; left: number }
+  border: { top: number; right: number; bottom: number; left: number }
+  margin: { top: number; right: number; bottom: number; left: number }
+}
+
 export interface SelectedElementData {
   selector: string
   computedStyles: Record<string, string>
+  boxModel?: BoxModel
   domSubtree: string
   boundingRect: DOMRect
   reactComponent?: {
@@ -66,6 +74,11 @@ export interface AnnotationData {
   coordinates: CircleCoords | ArrowCoords
   timestampMs: number
   nearestElement?: string
+  nearestElementContext?: {
+    computedStyles: Record<string, string>
+    boxModel?: BoxModel
+    domSubtree: string
+  }
 }
 
 export interface CircleCoords {


### PR DESCRIPTION
## Summary

Two enhancements that make each annotation a self-contained context unit for AI agents:

**#24 — Box model extraction:** New `getBoxModel()` function computes content/padding/border/margin breakdown from computed styles. Added to `SelectedElementData` and formatted in output as `320x48 (padding: 8 16px, border: 1px, margin: 0 8px)`.

**#21 — Element context on annotations:** When a circle or arrow resolves a nearest element, it now also runs `extractElementData()` and attaches computed styles, box model, and DOM subtree to the annotation data. Each annotation in the output now shows the full element context below it.

Both were the top requests from AI agent validation testing.

Fixes #21, fixes #24

## Test plan

- [x] All 84 tests pass
- [ ] Draw a circle on an element. Output should show computed styles, box model, and DOM subtree below the annotation line.
- [ ] Click an element in select mode. Output "Target Element" section should include box model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)